### PR TITLE
update config-file -> creds-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Usage of aws-session-go:
 
 ### Examples
 ```
-Usage: go run main.go -mfa-token <mfa-token> -profile <profile> -duration <duration> -config-file <path/to/credentials/file>
-Example: go run main.go -mfa-token 123456 -profile default -duration 3600 -config-file /path/to/credentials/file
+Usage: go run main.go -mfa-token <mfa-token> -profile <profile> -duration <duration> -creds-file <path/to/credentials/file>
+Example: go run main.go -mfa-token 123456 -profile default -duration 3600 -creds-file /path/to/credentials/file
 ```
 
 #### *Installation*

--- a/main.go
+++ b/main.go
@@ -1,19 +1,20 @@
 package main
 
 import (
-	"fmt"
 	"context"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/sts"
-	"strings"
 	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
 type inputArgs struct {
 	mfaToken string
 	duration int32
-	profile string
+	profile  string
 	credFile string
 }
 
@@ -22,19 +23,19 @@ func main() {
 	profile := flag.String("profile", "default", "AWS profile")
 	duration := flag.Int("duration", 3600, "Duration in seconds")
 	credFile := flag.String("creds-file", "", "Path to AWS credentials file")
-	help:= flag.Bool("help", false, "Show usage")
+	help := flag.Bool("help", false, "Show usage")
 	flag.Parse()
 
 	if *help {
-		fmt.Println("Usage: go run main.go -mfa-token <mfa-token> -profile <profile> -duration <duration> -config-file <path/to/credentials/file>")
-		fmt.Println("Example: go run main.go -mfa-token 123456 -profile default -duration 3600 -config-file /path/to/credentials/file")
+		fmt.Println("Usage: go run main.go -mfa-token <mfa-token> -profile <profile> -duration <duration> -creds-file <path/to/credentials/file>")
+		fmt.Println("Example: go run main.go -mfa-token 123456 -profile default -duration 3600 -creds-file /path/to/credentials/file")
 		return
 	}
 
-	if *mfaToken == ""{
+	if *mfaToken == "" {
 		fmt.Println("MFA token is required")
-		fmt.Println("Usage: go run main.go -mfa-token <mfa-token> -profile <profile> -duration <duration> -config-file <path/to/credentials/file>")
-		fmt.Println("Example: go run main.go -mfa-token 123456 -profile default -duration 3600 -config-file /path/to/credentials/file")
+		fmt.Println("Usage: go run main.go -mfa-token <mfa-token> -profile <profile> -duration <duration> -creds-file <path/to/credentials/file>")
+		fmt.Println("Example: go run main.go -mfa-token 123456 -profile default -duration 3600 -creds-file /path/to/credentials/file")
 		return
 	}
 
@@ -43,8 +44,6 @@ func main() {
 	fmt.Println("Duration: ", *duration)
 	fmt.Println("Config File: ", *credFile)
 
-
-
 	if *duration < 900 || *duration > 43200 {
 		fmt.Println("Duration must be between 900 and 43200 seconds (15 minutes and 12 hours)")
 		return
@@ -52,7 +51,7 @@ func main() {
 
 	sessionArgs := inputArgs{
 		mfaToken: *mfaToken,
-		profile: *profile,
+		profile:  *profile,
 		duration: int32(*duration),
 		credFile: *credFile,
 	}
@@ -79,20 +78,19 @@ func main() {
 		return
 	}
 
-	 
 	// Below is how to retrieve credentials from the config and print them
 	/*
-	data, retErr := cfg.Credentials.Retrieve(context.Background())
-	if retErr != nil {
-		fmt.Println("Error retrieving credentials, ", retErr)
-		fmt.Println("Please ensure you have a default profile in your ~/.aws/credentials file at minimum. If you have a different profile, you can specify it as an argument to this program. Example: go run main.go 123456 my-profile 3600")
-		return
-	}
+		data, retErr := cfg.Credentials.Retrieve(context.Background())
+		if retErr != nil {
+			fmt.Println("Error retrieving credentials, ", retErr)
+			fmt.Println("Please ensure you have a default profile in your ~/.aws/credentials file at minimum. If you have a different profile, you can specify it as an argument to this program. Example: go run main.go 123456 my-profile 3600")
+			return
+		}
 
-	// fmt.Println("Access Key: ", data.AccessKeyID)
-	// fmt.Println("Secret Key: ", data.SecretAccessKey)
-	// fmt.Println("Session Token: ", data.SessionToken)
-	// fmt.Println("Region: ", cfg.Region)
+		// fmt.Println("Access Key: ", data.AccessKeyID)
+		// fmt.Println("Secret Key: ", data.SecretAccessKey)
+		// fmt.Println("Session Token: ", data.SessionToken)
+		// fmt.Println("Region: ", cfg.Region)
 	*/
 
 	if cfg.Region == "" {
@@ -105,31 +103,30 @@ func main() {
 	if idErr != nil {
 		fmt.Println("Error getting identity: %s ", idErr)
 	}
-	
+
 	serialNumber := strings.Replace(*idResult.Arn, "user", "mfa", 1)
 	sessionInput := &sts.GetSessionTokenInput{
 		DurationSeconds: &sessionArgs.duration,
-		SerialNumber:  	 &serialNumber,
-		TokenCode :      &sessionArgs.mfaToken,
+		SerialNumber:    &serialNumber,
+		TokenCode:       &sessionArgs.mfaToken,
 	}
-	
+
 	sessionResult, sessionErr := client.GetSessionToken(context.Background(), sessionInput)
 	if sessionErr != nil {
 		fmt.Println("Error getting session token: ", sessionErr)
 		return
 	}
-	
+
 	/*
-	fmt.Println("Session Access Key: ", *sessionResult.Credentials.AccessKeyId)
-	fmt.Printf("Type: %T\n", *sessionResult.Credentials.AccessKeyId)
-	fmt.Println("Session Secret Key: ", *sessionResult.Credentials.SecretAccessKey)
-	fmt.Printf("Type: %T\n", *sessionResult.Credentials.SecretAccessKey)
-	fmt.Println("Session Token: ", *sessionResult.Credentials.SessionToken)
-	fmt.Printf("Type: %T\n", *sessionResult.Credentials.SessionToken)
-	fmt.Println("Session Expiration: ", *sessionResult.Credentials.Expiration)
-	fmt.Printf("Type: %T\n", *sessionResult.Credentials.Expiration)
+		fmt.Println("Session Access Key: ", *sessionResult.Credentials.AccessKeyId)
+		fmt.Printf("Type: %T\n", *sessionResult.Credentials.AccessKeyId)
+		fmt.Println("Session Secret Key: ", *sessionResult.Credentials.SecretAccessKey)
+		fmt.Printf("Type: %T\n", *sessionResult.Credentials.SecretAccessKey)
+		fmt.Println("Session Token: ", *sessionResult.Credentials.SessionToken)
+		fmt.Printf("Type: %T\n", *sessionResult.Credentials.SessionToken)
+		fmt.Println("Session Expiration: ", *sessionResult.Credentials.Expiration)
+		fmt.Printf("Type: %T\n", *sessionResult.Credentials.Expiration)
 	*/
 
-
-	updateConfig(sessionArgs.credFile, sessionArgs.profile + "-session", *sessionResult.Credentials.AccessKeyId, *sessionResult.Credentials.SecretAccessKey, *sessionResult.Credentials.SessionToken)
+	updateConfig(sessionArgs.credFile, sessionArgs.profile+"-session", *sessionResult.Credentials.AccessKeyId, *sessionResult.Credentials.SecretAccessKey, *sessionResult.Credentials.SessionToken)
 }


### PR DESCRIPTION
The `aws-session-go` tool expects `-creds-file` as an argument but the builtin help specified `-config-file`:

```
~> aws-session-go
MFA token is required
Usage: go run main.go -mfa-token <mfa-token> -profile <profile> -duration <duration> -config-file <path/to/credentials/file>
Example: go run main.go -mfa-token 123456 -profile default -duration 3600 -config-file /path/to/credentials/file
```

This updates that for consistency.

(The other changes are just the Go plugin for VS Code reformatting. )
