### PR TITLE
Add aws_session_expiration to profile section in aws creds

### DIFF
--- a/main.go
+++ b/main.go
@@ -128,5 +128,12 @@ func main() {
 		fmt.Printf("Type: %T\n", *sessionResult.Credentials.Expiration)
 	*/
 
-	updateConfig(sessionArgs.credFile, sessionArgs.profile+"-session", *sessionResult.Credentials.AccessKeyId, *sessionResult.Credentials.SecretAccessKey, *sessionResult.Credentials.SessionToken)
+	updateConfig(
+		sessionArgs.credFile,
+		sessionArgs.profile+"-session",
+		*sessionResult.Credentials.AccessKeyId,
+		*sessionResult.Credentials.SecretAccessKey,
+		*sessionResult.Credentials.SessionToken,
+		sessionResult.Credentials.Expiration.UTC().Format("2006-01-02 15:04:05.000000-07:00"), // ISO 8601
+	)
 }

--- a/updateIni.go
+++ b/updateIni.go
@@ -6,7 +6,7 @@ import (
 	"os/user"
 )
 
-func updateConfig(credFile string, profile string, accessKey string, secretKey string, sessionToken string) {
+func updateConfig(credFile, profile, accessKey, secretKey, sessionToken, expiration string) {
 	if credFile == "" {
 		usr, err := user.Current()
 		if err != nil {
@@ -21,16 +21,14 @@ func updateConfig(credFile string, profile string, accessKey string, secretKey s
 		return
 	}
 
-	if cfg.HasSection(profile) {
-		cfg.Section(profile).Key("aws_access_key_id").SetValue(accessKey)
-		cfg.Section(profile).Key("aws_secret_access_key").SetValue(secretKey)
-		cfg.Section(profile).Key("aws_session_token").SetValue(sessionToken)
-	} else {
+	if !cfg.HasSection(profile) {
 		cfg.NewSection(profile)
-		cfg.Section(profile).Key("aws_access_key_id").SetValue(accessKey)
-		cfg.Section(profile).Key("aws_secret_access_key").SetValue(secretKey)
-		cfg.Section(profile).Key("aws_session_token").SetValue(sessionToken)
 	}
+
+	cfg.Section(profile).Key("aws_access_key_id").SetValue(accessKey)
+	cfg.Section(profile).Key("aws_secret_access_key").SetValue(secretKey)
+	cfg.Section(profile).Key("aws_session_token").SetValue(sessionToken)
+	cfg.Section(profile).Key("aws_session_expiration").SetValue(expiration)
 
 	err = cfg.SaveTo(credFile)
 	if err != nil {


### PR DESCRIPTION
Useful for future logic or custom helper script to check whether a new token needs to be generated.